### PR TITLE
oraclelinux 7.x is the last to support Forms

### DIFF
--- a/OracleJava/java-8/Dockerfile
+++ b/OracleJava/java-8/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Dockerfile for creating Oracle JDK 1.8_151 Images based on OL latest
 #
-FROM oraclelinux:latest
+FROM oraclelinux:7.8
 
 MAINTAINER Dirk Nachbar <https://dirknachbar.blogspot.com>
 


### PR DESCRIPTION
There is no latest tag and those in the 8.x series don't have old enough libraries